### PR TITLE
Add mock SSE endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,7 @@ DEBUG_CONSOLE=false
 #                     Endpoints                     #
 #===================================================#
 
-# ENDPOINTS=openAI,assistants,azureOpenAI,google,anthropic
+# ENDPOINTS=openAI,assistants,azureOpenAI,google,anthropic,mock
 
 PROXY=
 

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -115,6 +115,7 @@ const startServer = async () => {
   app.use('/api/share', routes.share);
   app.use('/api/roles', routes.roles);
   app.use('/api/agents', routes.agents);
+  app.use('/api/mock', routes.mock);
   app.use('/api/banner', routes.banner);
   app.use('/api/memories', routes.memories);
   app.use('/api/tags', routes.tags);

--- a/api/server/routes/index.js
+++ b/api/server/routes/index.js
@@ -26,6 +26,7 @@ const edit = require('./edit');
 const keys = require('./keys');
 const user = require('./user');
 const mcp = require('./mcp');
+const mock = require('./mock');
 
 module.exports = {
   edit,
@@ -54,6 +55,7 @@ module.exports = {
   tokenizer,
   assistants,
   categories,
+  mock,
   staticRoute,
   mcp,
 };

--- a/api/server/routes/mock/chat.js
+++ b/api/server/routes/mock/chat.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const { setHeaders } = require('~/server/middleware');
+const { sendEvent } = require('@librechat/api');
+
+const router = express.Router();
+
+router.use(setHeaders);
+
+router.post('/', async (req, res) => {
+  const events = [
+    { text: '<p>Hello from <strong>mock</strong> endpoint.</p>' },
+    { text: '<p>This is a <em>mocked</em> response.</p>', final: true },
+  ];
+
+  let idx = 0;
+  const interval = setInterval(() => {
+    const event = events[idx];
+    if (!event) {
+      clearInterval(interval);
+      res.end();
+      return;
+    }
+    sendEvent(res, event);
+    idx += 1;
+    if (event.final) {
+      clearInterval(interval);
+      res.end();
+    }
+  }, 1000);
+});
+
+module.exports = router;

--- a/api/server/routes/mock/index.js
+++ b/api/server/routes/mock/index.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const chat = require('./chat');
+
+router.use('/chat', chat);
+
+module.exports = router;

--- a/api/server/services/Config/EndpointService.js
+++ b/api/server/services/Config/EndpointService.js
@@ -47,6 +47,7 @@ module.exports = {
     [EModelEndpoint.bedrock]: generateConfig(
       process.env.BEDROCK_AWS_SECRET_ACCESS_KEY ?? process.env.BEDROCK_AWS_DEFAULT_REGION,
     ),
+    [EModelEndpoint.mock]: generateConfig('mock-key'),
     /* key will be part of separate config */
     [EModelEndpoint.agents]: generateConfig('true', undefined, EModelEndpoint.agents),
   },

--- a/api/server/services/Config/loadDefaultEConfig.js
+++ b/api/server/services/Config/loadDefaultEConfig.js
@@ -24,6 +24,7 @@ async function loadDefaultEndpointsConfig(req) {
     [EModelEndpoint.gptPlugins]: gptPlugins,
     [EModelEndpoint.anthropic]: config[EModelEndpoint.anthropic],
     [EModelEndpoint.bedrock]: config[EModelEndpoint.bedrock],
+    [EModelEndpoint.mock]: config[EModelEndpoint.mock],
   };
 
   const orderedAndFilteredEndpoints = enabledEndpoints.reduce((config, key, index) => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -970,6 +970,7 @@ export const defaultModels = {
     'gpt-3.5-turbo-instruct',
   ],
   [EModelEndpoint.bedrock]: bedrockModels,
+  [EModelEndpoint.mock]: ['mock-model'],
 };
 
 const fitlerAssistantModels = (str: string) => {
@@ -995,6 +996,7 @@ export const EndpointURLs = {
   [EModelEndpoint.assistants]: '/api/assistants/v2/chat',
   [EModelEndpoint.azureAssistants]: '/api/assistants/v1/chat',
   [EModelEndpoint.agents]: `/api/${EModelEndpoint.agents}/chat`,
+  [EModelEndpoint.mock]: '/api/mock/chat',
 } as const;
 
 export const modularEndpoints = new Set<EModelEndpoint | string>([
@@ -1006,6 +1008,7 @@ export const modularEndpoints = new Set<EModelEndpoint | string>([
   EModelEndpoint.custom,
   EModelEndpoint.agents,
   EModelEndpoint.bedrock,
+  EModelEndpoint.mock,
 ]);
 
 export const supportsBalanceCheck = {
@@ -1018,6 +1021,7 @@ export const supportsBalanceCheck = {
   [EModelEndpoint.azureAssistants]: true,
   [EModelEndpoint.azureOpenAI]: true,
   [EModelEndpoint.bedrock]: true,
+  [EModelEndpoint.mock]: false,
 };
 
 export const visionModels = [

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -62,6 +62,7 @@ export function getEnabledEndpoints() {
     EModelEndpoint.gptPlugins,
     EModelEndpoint.anthropic,
     EModelEndpoint.bedrock,
+    EModelEndpoint.mock,
   ];
 
   const endpointsEnv = process.env.ENDPOINTS ?? '';

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -25,6 +25,7 @@ export enum EModelEndpoint {
   agents = 'agents',
   custom = 'custom',
   bedrock = 'bedrock',
+  mock = 'mock',
   /** @deprecated */
   chatGPTBrowser = 'chatGPTBrowser',
   /** @deprecated */


### PR DESCRIPTION
## Summary
- add example `.env` entry for `mock` endpoint
- create `/api/mock/chat` SSE route returning dummy messages
- expose `mock` route from server and include in server index
- configure default endpoints to include the mock option

## Testing
- `npm run test:api` *(fails: Cannot find module 'librechat-data-provider')*

------
https://chatgpt.com/codex/tasks/task_e_68825a9888608326a6f7cdd7c62034b6